### PR TITLE
(NR.1(ny))listByActivity().EquipmentServiceImpl.java

### DIFF
--- a/src/main/java/org/example/adventurexp/service/EquipmentServiceImpl.java
+++ b/src/main/java/org/example/adventurexp/service/EquipmentServiceImpl.java
@@ -32,4 +32,9 @@ public class EquipmentServiceImpl implements IEquipmentService {
             return equipmentList.stream().mapToInt(Equipment::getUsableSets).sum();
         }
     }
+
+    @Override
+    public List<Equipment> listByActivity(long activityId) {
+        return getEquipmentByActivityId(activityId);
+    }
 }

--- a/src/main/java/org/example/adventurexp/service/IEquipmentService.java
+++ b/src/main/java/org/example/adventurexp/service/IEquipmentService.java
@@ -14,5 +14,5 @@ public interface IEquipmentService {
 
     int usableSets(Activity activity);
 
-
+    List<Equipment> listByActivity(long activityId);
 }


### PR DESCRIPTION
# Hvad
EquipmentServiceImpl fik en listByActivity(), men det betød at IEquipmentService.java(interfacet) også skulle have den.

# Test
niet

# Acceptance
<!-- Hvornår kan denne PR siges at være godkendt? -->
- [x] Koden er gennemgået af mindst én reviewer
- [x] Alle tests kører uden fejl
- [ ] **SKAL** merges ind **FØR** #60 



---